### PR TITLE
Fixed a regression that made tasks never complete

### DIFF
--- a/src/Tasks/Turn.cs
+++ b/src/Tasks/Turn.cs
@@ -44,7 +44,6 @@ namespace CivOne.Tasks
 			if (_turnObject != null)
 			{
 				_turnObject.NewTurn();
-				return;
 			}
 			else if (_unit != null)
 			{


### PR DESCRIPTION
I'm not sure what the idea was behind this short circuit in `Turn` but it basically made tasks never ending and would stall the game on game start.