### PR TITLE
Small fixes to tile yield and text rendering on city tiles

### DIFF
--- a/src/City.cs
+++ b/src/City.cs
@@ -186,8 +186,6 @@ namespace CivOne
 			{
 				case Terrain.Desert:
 				case Terrain.Forest:
-					if (!Player.AnarchyDespotism) output += 1;
-					break;
 				case Terrain.Grassland1:
 				case Terrain.Grassland2:
 				case Terrain.River:
@@ -237,6 +235,7 @@ namespace CivOne
 		internal int TradeValue(ITile tile)
 		{
 			int output = tile.Trade;
+
 			if (tile.RailRoad) output = (int)Math.Floor((double)output * 1.5);
 			switch (tile.Type)
 			{

--- a/src/GFX/Icons.cs
+++ b/src/GFX/Icons.cs
@@ -252,14 +252,7 @@ namespace CivOne.GFX
 			Picture.ReplaceColours(resource, 3, 0);
 			Picture.ReplaceColours(resource, 5, Common.ColourDark[city.Owner]);
 			output.AddLayer(resource, 0, 0);
-			if (city.Size > 9)
-			{
-				output.DrawText($"{city.Size}", (smallFont ? 1 : 0), 5, 5, 8, 5, TextAlign.Center);
-			}
-			else
-			{
-				output.DrawText($"{city.Size}", (smallFont ? 1 : 0), 5, 5, 9, 5, TextAlign.Center);
-			}
+			output.DrawText($"{city.Size}", (smallFont ? 1 : 0), 5, 5, 9, 5, TextAlign.Center);
 
 			if (city.HasBuilding<CityWalls>())
 			{

--- a/src/GFX/Picture.cs
+++ b/src/GFX/Picture.cs
@@ -144,7 +144,7 @@ namespace CivOne.GFX
 			switch (align)
 			{
 				case TextAlign.Center:
-					x -= (textImage.Width / 2);
+					x -= (textImage.Width + 1) / 2;
 					break;
 				case TextAlign.Right:
 					x -= textImage.Width;

--- a/src/Tiles/Grassland.cs
+++ b/src/Tiles/Grassland.cs
@@ -50,7 +50,7 @@ namespace CivOne.Tiles
 		{
 			get
 			{
-				return (sbyte)(Road || RailRoad ? 1 : 0);
+				return (sbyte)((Road || RailRoad) ? 1 : 0);
 			}
 		}
 		

--- a/src/Tiles/Plains.cs
+++ b/src/Tiles/Plains.cs
@@ -50,7 +50,7 @@ namespace CivOne.Tiles
 		{
 			get
 			{
-				return (sbyte)(Road || RailRoad ? 1 : 0);
+				return (sbyte)((Road || RailRoad) ? 1 : 0);
 			}
 		}
 		


### PR DESCRIPTION
The `1` (possibly other numbers as well) rendered on the city tile was off by 1 pixel. This fixes that and eliminates the need for your `city.Size > 9` special case.

Other than that I made small fixes to tile yields.