### PR TITLE
Centering map on active asset after game load

### DIFF
--- a/src/Screens/GamePlay.cs
+++ b/src/Screens/GamePlay.cs
@@ -364,6 +364,7 @@ namespace CivOne.Screens
 				}
 			}
 
+			// if there is no active unit center on random human player city
 			foreach (City city in Game.GetCities())
 			{
 				if (city.Owner == Game.PlayerNumber(Game.HumanPlayer))

--- a/src/Screens/GamePlay.cs
+++ b/src/Screens/GamePlay.cs
@@ -16,6 +16,7 @@ using CivOne.Screens.Dialogs;
 using CivOne.Screens.GamePlayPanels;
 using CivOne.Screens.Reports;
 using CivOne.Tasks;
+using CivOne.Units;
 using CivOne.UserInterface;
 
 namespace CivOne.Screens
@@ -351,7 +352,28 @@ namespace CivOne.Screens
 			_update = true;
 			HasUpdate(0);
 		}
-		
+
+		private void centerMapOnActiveHumanPlayerAsset()
+		{
+			foreach (IUnit unit in Game.GetUnits().OrderByDescending(u => u.MovesLeft))
+			{
+				if (unit.Owner == Game.PlayerNumber(Game.HumanPlayer))
+				{
+					_gameMap.CenterOnPoint(unit.X, unit.Y);
+					return;
+				}
+			}
+
+			foreach (City city in Game.GetCities())
+			{
+				if (city.Owner == Game.PlayerNumber(Game.HumanPlayer))
+				{
+					_gameMap.CenterOnPoint(city.X, city.Y);
+					return;
+				}
+			}
+		}
+
 		public GamePlay()
 		{
 			OnResize += Resize;
@@ -363,6 +385,8 @@ namespace CivOne.Screens
 			_menuBar = new MenuBar(Palette);
 			_sideBar = new SideBar(Palette);
 			_gameMap = new GameMap();
+
+			centerMapOnActiveHumanPlayerAsset();
 
 			if (Width != 320 || Height != 200)
 			{

--- a/src/Screens/GamePlay.cs
+++ b/src/Screens/GamePlay.cs
@@ -353,7 +353,7 @@ namespace CivOne.Screens
 			HasUpdate(0);
 		}
 
-		private void centerMapOnActiveHumanPlayerAsset()
+		private void CenterMapOnActiveHumanPlayerAsset()
 		{
 			foreach (IUnit unit in Game.GetUnits().OrderByDescending(u => u.MovesLeft))
 			{
@@ -387,7 +387,7 @@ namespace CivOne.Screens
 			_sideBar = new SideBar(Palette);
 			_gameMap = new GameMap();
 
-			centerMapOnActiveHumanPlayerAsset();
+			CenterMapOnActiveHumanPlayerAsset();
 
 			if (Width != 320 || Height != 200)
 			{


### PR DESCRIPTION
map is now centered on random human player active unit (if there is none on city) after game load instead of random place on map