### PR TITLE
Graphics modifications: Draw each layer on a seperate texture

### DIFF
--- a/runtime/sdl/src/Extensions.cs
+++ b/runtime/sdl/src/Extensions.cs
@@ -1,3 +1,12 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 using CivOne.Enums;
 
 namespace CivOne

--- a/runtime/sdl/src/GameWindow.Graphics.cs
+++ b/runtime/sdl/src/GameWindow.Graphics.cs
@@ -10,6 +10,7 @@
 using System.Drawing;
 using System.Linq;
 using CivOne.Enums;
+using CivOne.IO;
 
 namespace CivOne
 {
@@ -42,7 +43,9 @@ namespace CivOne
 
 			Clear(Color.Black);
 			GetBorders(out int x1, out int y1, out int x2, out int y2);
-			using (SDL.Texture canvas = CreateTexture(_runtime.Bitmap))
+			if (_runtime.Layers == null) return;
+			foreach (Bytemap bytemap in _runtime.Layers)
+			using (SDL.Texture canvas = CreateTexture(_runtime.Palette, bytemap))
 			{
 				canvas.Draw(x1, y1, (x2 - x1), (y2 - y1));
 				

--- a/runtime/sdl/src/Resources.cs
+++ b/runtime/sdl/src/Resources.cs
@@ -1,3 +1,12 @@
+// CivOne
+//
+// To the extent possible under law, the person who associated CC0 with
+// CivOne has waived all copyright and related or neighboring rights
+// to CivOne.
+//
+// You should have received a copy of the CC0 legalcode along with this
+// work. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+
 using System;
 using System.IO;
 using System.Linq;

--- a/runtime/sdl/src/Runtime.cs
+++ b/runtime/sdl/src/Runtime.cs
@@ -12,6 +12,7 @@ using System.Drawing;
 using System.IO;
 using CivOne.Enums;
 using CivOne.Events;
+using CivOne.IO;
 using CivOne.Graphics;
 
 namespace CivOne
@@ -44,7 +45,8 @@ namespace CivOne
 		
 		public RuntimeSettings Settings { get; private set; }
 		public MouseCursor CurrentCursor { internal get; set; }
-		public IBitmap Bitmap { get; set; }
+		public Bytemap[] Layers { get; set; }
+		public Palette Palette { get; set; }
 		private IBitmap _cursor;
 		public IBitmap Cursor
 		{

--- a/runtime/sdl/src/SDL/Texture.cs
+++ b/runtime/sdl/src/SDL/Texture.cs
@@ -56,28 +56,28 @@ namespace CivOne
 				SDL_RenderCopy(_renderer, _handle, ref src, ref dst);
 			}
 
-			internal Texture(IntPtr renderer, IBitmap bitmap)
+			internal Texture(IntPtr renderer, Palette palette, Bytemap bytemap)
 			{
-				if (bitmap == null)
+				if (palette == null || bytemap == null)
 				{
 					// Do not load empty bitmap
 					_handle = IntPtr.Zero;
 					return;
 				}
 
-				Width = bitmap.Width();
-				Height = bitmap.Height();
+				Width = bytemap.Width;
+				Height = bytemap.Height;
 
 				_renderer = renderer;
 				_handle = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ABGR8888, SDL_TextureAccess.SDL_TEXTUREACCESS_STREAMING, Width, Height);
 				SDL_Rect rect = new SDL_Rect() { X = 0, Y = 0, W = Width, H = Height };
-				int[] palette = PaletteArray(bitmap.Palette);
-				bool hasAlpha = bitmap.Palette.Entries.Any(x => x.A != 255);
-				if (HasAlpha(bitmap.Palette)) SDL_SetTextureBlendMode(_handle, SDL_BlendMode.SDL_BLENDMODE_BLEND);
+				int[] paletteData = PaletteArray(palette);
+				bool hasAlpha = palette.Entries.Any(x => x.A != 255);
+				if (HasAlpha(palette)) SDL_SetTextureBlendMode(_handle, SDL_BlendMode.SDL_BLENDMODE_BLEND);
 				if (SDL_LockTexture(_handle, ref rect, out IntPtr pixels, out int pitch) == 0)
 				{
-					int[] src = bitmap.Bitmap.ToColourMap(palette);
-					Marshal.Copy(bitmap.Bitmap.ToColourMap(palette), 0, pixels, Width * Height);
+					int[] src = bytemap.ToColourMap(paletteData);
+					Marshal.Copy(bytemap.ToColourMap(paletteData), 0, pixels, Width * Height);
 					SDL_UnlockTexture(_handle);
 				}
 			}

--- a/runtime/sdl/src/SDL/Window.cs
+++ b/runtime/sdl/src/SDL/Window.cs
@@ -29,7 +29,8 @@ namespace CivOne
 
 			protected event Action<string> OnLog;
 
-			protected Texture CreateTexture(IBitmap bitmap) => new Texture(_renderer, bitmap);
+			protected Texture CreateTexture(IBitmap bitmap) => new Texture(_renderer, bitmap?.Palette, bitmap?.Bitmap);
+			protected Texture CreateTexture(Palette palette, Bytemap bytemap) => new Texture(_renderer, palette, bytemap);
 
 			protected void Clear(Color color)
 			{

--- a/src/IRuntime.cs
+++ b/src/IRuntime.cs
@@ -11,6 +11,7 @@ using System;
 using CivOne.Enums;
 using CivOne.Events;
 using CivOne.Graphics;
+using CivOne.IO;
 
 namespace CivOne
 {
@@ -26,7 +27,8 @@ namespace CivOne
 		void SetSetting(string key, string value);
 		RuntimeSettings Settings { get; }
 		MouseCursor CurrentCursor { set; }
-		IBitmap Bitmap { get; set; }
+		Bytemap[] Layers { get; set; }
+		Palette Palette { get; set; }
 		IBitmap Cursor { set; }
 		int CanvasWidth { get; }
 		int CanvasHeight { get; }

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -68,8 +68,6 @@ namespace CivOne
 				Common.ReloadSettings = true;
 				
 				Resources.ClearInstance();
-				Runtime.Bitmap?.Dispose();
-				Runtime.Bitmap = null;
 			}
 		}
 		


### PR DESCRIPTION
This change uses slighly more memory (about 2-5 MB during my tests), but it will make it easier, in the future, to add custom drawing commands in order to allow high resolution 32-bit textures and fonts.